### PR TITLE
Fix compilation on Linux

### DIFF
--- a/src/boilerplate.h
+++ b/src/boilerplate.h
@@ -31,7 +31,12 @@
 #include <stdlib.h> // exit
 #include <libgen.h> // basename
 #include <sys/wait.h>
-#include <limits.h> // PATH_MAX
+
+#if defined(__BSD__)
+#    include <limits.h> // PATH_MAX for BSD
+#else
+#    include <linux/limits.h> // PATH_MAX for Linux
+#endif
 
 #ifdef HAVE_MEMFD
 #    include <sys/syscall.h> // syscall, SYS_memfd_create


### PR DESCRIPTION
After 60654b06da413fb244704fd3352a5447ed3921e3 compilation seems to be broken on Linux because PATH_MAX is not defined in limits.h. See #29 

> ../src/boilerplate.c:675:28: error: ‘PATH_MAX’ undeclared (first use in this function); did you mean ‘INT8_MAX’

Build only tested on Linux.