### PR TITLE
Fix POSIX definitions not being available with C99 (switch to GNU99)

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('wl-clipboard', 'c',
     version: '1.0.0',
     meson_version: '>= 0.44.0',
-    default_options: 'c_std=c99'
+    default_options: 'c_std=gnu99'
 )
 
 subdir('src')


### PR DESCRIPTION
Fixes issue #29 
Fixes POSIX definitions not being available on some systems, including

- `PATH_MAX` not being defined
- `strdup` not being defined
- `mkdtemp` not being defined
- `syscall` not being defined
- `fileno` not being defined
- `ftruncate` not being defined

This is an alternative solution to PR #28.