### PR TITLE
zshcompdir build option

### DIFF
--- a/completions/zsh/_wl-paste
+++ b/completions/zsh/_wl-paste
@@ -1,12 +1,13 @@
 #compdef wl-paste
 
+local expl
+typeset -A opt_args
+
 _wl-paste_types() {
 	local -a types args
 	args=(
-		${(k)opt_args[-p]}
-		${(k)opt_args[--primary]}
-		${(k)opt_args[-s]} ${(v)opt_args[-s]}
-		${(k)opt_args[--seat]} ${(v)opt_args[--seat]}
+		${(kv)opt_args[(I)-p|--primary]}
+		${(kv)opt_args[(I)-s|--seat]}
 	)
 	types=( ${(@f)"$(wl-paste $args -l 2>/dev/null)"} )
 
@@ -23,19 +24,18 @@ __all_seats() {
 	fi
 
 	if [[ -z $seats ]]; then
-		# seat0 is always a vaild seat and covers most cases, so its a good fallback.
+		# seat0 covers most cases, so its a good fallback.
 		compadd "$@" - seat0
 	else
 		compadd "$@" -a seats
 	fi
 }
 
-typeset -A opt_args
 _arguments -S -s \
 	{-n,--no-newline}'[Do not append a newline character]' \
 	{-l,--list-types}'[Instead of pasting, list the offered types]' \
 	{-p,--primary}'[Use the "primary" clipboard]' \
-	{-w+,--watch=}'[Run a command wach time the selection changes]:*::command:_normal' \
+	{-w,--watch}'[Run a command wach time the selection changes]:*::command:_normal' \
 	{-t+,--type=}'[Override the inferred MIME type for the content]:mimetype:_wl-paste_types' \
 	{-s+,--seat=}'[Pick the seat to work with]:seat:__all_seats' \
 	{-v,--version}'[Display version info]' \

--- a/completions/zsh/meson.build
+++ b/completions/zsh/meson.build
@@ -1,4 +1,9 @@
-zsh_completion_dir = join_paths(get_option('datadir'), 'zsh', 'site-functions')
+zsh_completion_dir = get_option('zshcompletiondir')
+if zsh_completion_dir == ''
+    zsh_completion_dir = join_paths(get_option('datadir'), 'zsh', 'site-functions')
+endif
 
-install_data('_wl-copy', install_dir: zsh_completion_dir)
-install_data('_wl-paste', install_dir: zsh_completion_dir)
+if zsh_completion_dir != 'no'
+    install_data('_wl-copy', install_dir: zsh_completion_dir)
+    install_data('_wl-paste', install_dir: zsh_completion_dir)
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,5 @@
+option('zshcompletiondir',
+    type: 'string',
+    value: '',
+    description: 'Directory for zsh completions. Set "no" to disable.'
+)


### PR DESCRIPTION
Quick fix for comment in #56

1. Debian uses non-standard zsh completion dir, so add a build option for it. Let users set "no" to just not install them if they don't want.
2. Don't complete a '=' following --watch or allow other options to stack after -w

Also,

3. reuse all --seat/-s arguments when querying types if the user specifies --seat/-s more than once. 