### PR TITLE
memset options to avoid uninitialized memory

### DIFF
--- a/src/wl-copy.c
+++ b/src/wl-copy.c
@@ -181,6 +181,7 @@ static void parse_options(int argc, argv_t argv) {
 }
 
 int main(int argc, argv_t argv) {
+    memset(&options, 0, sizeof(options));
     parse_options(argc, argv);
 
     struct wl_display *wl_display = wl_display_connect(NULL);


### PR DESCRIPTION
Ran across this while implementing the loops option: The global `options` variable should be zero'd before usage to avoid uninitialized memory.

IIRC, gcc is pretty defensive in this and zero's out memory even in release builds, but I'm pretty sure it's not required by any standard.