### PR TITLE
Infer valid text to offer it as text/plain

### DIFF
--- a/src/util/files.c
+++ b/src/util/files.c
@@ -102,6 +102,28 @@ char *path_for_fd(int fd) {
     return realpath(fdpath, NULL);
 }
 
+int infer_is_text_plain_utf8(const char *file_path) {
+    /* Infer if the file is valid UTF-8 text */
+    pid_t pid = fork();
+    if (pid < 0) {
+        perror("fork");
+        return 0;
+    }
+    if (pid == 0) {
+        int devnull = open("/dev/null", O_WRONLY);
+        dup2(devnull, STDOUT_FILENO);
+        dup2(devnull, STDERR_FILENO);
+        execlp("iconv", "iconv", "-f", "utf-8", "-t", "utf-8", file_path, NULL);
+        exit(1);
+    }
+
+    int wstatus;
+    wait(&wstatus);
+
+    /* A successful conversion will return zero */
+    return WIFEXITED(wstatus) && WEXITSTATUS(wstatus) == 0;
+}
+
 char *infer_mime_type_from_contents(const char *file_path) {
     /* Spawn xdg-mime query filetype */
     int pipefd[2];

--- a/src/util/files.h
+++ b/src/util/files.h
@@ -20,6 +20,7 @@
 #define UTIL_FILES_H
 
 int create_anonymous_file(void);
+int infer_is_text_plain_utf8(const char *file_path);
 
 void trim_trailing_newline(const char *file_path);
 

--- a/src/wl-copy.c
+++ b/src/wl-copy.c
@@ -249,7 +249,8 @@ int main(int argc, argv_t argv) {
         if (options.mime_type != NULL) {
             source_offer(copy_action->source, options.mime_type);
         }
-        if (options.mime_type == NULL || mime_type_is_text(options.mime_type)) {
+        if (options.mime_type == NULL || mime_type_is_text(options.mime_type)
+                || infer_is_text_plain_utf8(copy_action->file_to_copy)) {
             /* Offer a few generic plain text formats */
             source_offer(copy_action->source, text_plain);
             source_offer(copy_action->source, text_plain_utf8);


### PR DESCRIPTION
To deal with xdg-open issues and some MIME types such as application/csv not getting correctly picked up as text, it might be good to recognize inputs which are valid text and offer them as such.

This commit adds an `infer_is_text_plain_utf8` function, which is currently implemented by running an iconv conversion from UTF-8 into UTF-8, which will succeed only if the input is valid UTF-8 text. This function will run if `mime_type_is_text` is false. This probably isn't the most efficient implementation, since iconv will read through the entire file, however it should fail early for binary files more likely to be large in size.