### PR TITLE
Switch stdout to /dev/null before forking wl-copy

### DIFF
--- a/src/util/files.c
+++ b/src/util/files.c
@@ -123,8 +123,13 @@ char *infer_mime_type_from_contents(const char *file_path) {
         close(pipefd[0]);
         close(pipefd[1]);
         int devnull = open("/dev/null", O_RDONLY);
-        dup2(devnull, STDIN_FILENO);
-        close(devnull);
+        if (devnull >= 0) {
+            dup2(devnull, STDIN_FILENO);
+            close(devnull);
+        } else {
+            /* If we cannot open /dev/null, just close stdin */
+            close(STDIN_FILENO);
+        }
         execlp("xdg-mime", "xdg-mime", "query", "filetype", file_path, NULL);
         exit(1);
     }


### PR DESCRIPTION
Since wl-copy doesn't send anything to stdout after forking, it
shouldn't keep the stdout file descriptor open and hold up a pipeline.

Fixes https://github.com/bugaevc/wl-clipboard/issues/100