### PR TITLE
Also close stderr file descriptor

### DIFF
--- a/src/wl-copy.c
+++ b/src/wl-copy.c
@@ -54,7 +54,7 @@ static void did_set_selection_callback(struct copy_action *copy_action) {
          * We fork our process and leave the
          * child running in the background,
          * while exiting in the parent.
-         * Also replace stdin/stdout with
+         * Also replace stdin/stdout/stderr with
          * /dev/null so the stdout file
          * descriptor isn't kept alive.
          */
@@ -62,11 +62,13 @@ static void did_set_selection_callback(struct copy_action *copy_action) {
         if (devnull >= 0) {
             dup2(devnull, STDOUT_FILENO);
             dup2(devnull, STDIN_FILENO);
+            dup2(devnull, STDERR_FILENO);
             close(devnull);
         } else {
-            /* If we cannot open /dev/null, just close stdin/stdout */
+            /* If we cannot open /dev/null, just close stdin/stdout/stderr */
             close(STDIN_FILENO);
             close(STDOUT_FILENO);
+            close(STDERR_FILENO);
         }
         pid_t pid = fork();
         if (pid < 0) {


### PR DESCRIPTION
This is similar to aa4633b8 but for stderr.

It can be reproduced with the following shell pipe line which does not terminate.
```
echo "text to copy" | wl-copy 2>&1 >/dev/null | cat
```
This fixes [an issue](https://github.com/martanne/vis/issues/929) I was having with a text editor.