### PR TITLE
Ignore SIGHUP in wl-copy

### DIFF
--- a/src/wl-copy.c
+++ b/src/wl-copy.c
@@ -33,6 +33,7 @@
 #include <fcntl.h> // open
 #include <libgen.h>
 #include <getopt.h>
+#include <signal.h>
 
 static struct {
     int stay_in_foreground;
@@ -68,6 +69,7 @@ static void did_set_selection_callback(struct copy_action *copy_action) {
             close(STDIN_FILENO);
             close(STDOUT_FILENO);
         }
+        signal(SIGHUP, SIG_IGN);
         pid_t pid = fork();
         if (pid < 0) {
             perror("fork");


### PR DESCRIPTION
Running e.g `foot wl-copy foobar`, `alacritty -e wl-copy foobar` or `xterm -e wl-copy foobar` results in the forked copy of wl-copy being terminated and _"foobar”_ no longer being paste:able.

This happens because it (the forked copy) receives a `SIGHUP` when the terminal exits, which terminates wl-copy.

This patch fixes this by ignoring `SIGHUP`. Technically, this is only needed in the forked wl-copy. But, to handle the examples above, the handler needs to be installed **before** the parent wl-copy exits.

To avoid a race condition, ignore `SIGHUP` before the fork. This should be ok since the parent wl-copy exits almost immediately after the fork.