### PR TITLE
Stop wl-paste from offering SAVE_TARGETS as a type

### DIFF
--- a/src/types/offer.c
+++ b/src/types/offer.c
@@ -42,6 +42,7 @@ static void type ## _offer_handler( \
     struct type *proxy, \
     const char *mime_type \
 ) { \
+    if (!strcmp(mime_type, "SAVE_TARGETS")) return; \
     struct offer *self = data; \
     char *ptr = wl_array_add( \
         &self->offered_mime_types, \


### PR DESCRIPTION
SAVE_TARGETS is strictly for x11 clipboard managers that use the freedesktop api https://www.freedesktop.org/wiki/ClipboardManager as such wl-clipboard should ignore it. In some cases such as `firefox` calling `wl-paste -t SAVE_TARGETS` will cause it to hang.