### PR TITLE
Close stderr before forking wl-copy

### DIFF
--- a/src/wl-copy.c
+++ b/src/wl-copy.c
@@ -55,7 +55,7 @@ static void did_set_selection_callback(struct copy_action *copy_action) {
          * We fork our process and leave the
          * child running in the background,
          * while exiting in the parent.
-         * Also replace stdin/stdout with
+         * Also replace stdin/stdout/stderr with
          * /dev/null so the stdout file
          * descriptor isn't kept alive.
          */
@@ -63,11 +63,13 @@ static void did_set_selection_callback(struct copy_action *copy_action) {
         if (devnull >= 0) {
             dup2(devnull, STDOUT_FILENO);
             dup2(devnull, STDIN_FILENO);
+            dup2(devnull, STDERR_FILENO);
             close(devnull);
         } else {
-            /* If we cannot open /dev/null, just close stdin/stdout */
+            /* If we cannot open /dev/null, just close stdin/stdout/stderr */
             close(STDIN_FILENO);
             close(STDOUT_FILENO);
+            close(STDERR_FILENO);
         }
         signal(SIGHUP, SIG_IGN);
         pid_t pid = fork();


### PR DESCRIPTION
The default mode of the kitty terminal is to wait until output from all subprocesses is finished before closing.  This means running `wl-copy asdf; exit` will exit the shell but cause kitty to hang as it waits for wl-copy to output.  This change closes stderr to prevent this issue.