### PR TITLE
fix "error: format not a string literal and no format arguments [-Wer…

### DIFF
--- a/src/util/files.c
+++ b/src/util/files.c
@@ -74,7 +74,7 @@ void complain_about_closed_stdio(struct wl_display *wl_display) {
 
     /* As a last resort, try syslog */
     openlog("wl-clipboard", LOG_CONS | LOG_PID, LOG_USER);
-    syslog(LOG_ERR, message);
+    syslog(LOG_ERR, "%s", message);
     closelog();
     abort();
 }


### PR DESCRIPTION
…ror=format-security]"

https://fedoraproject.org/wiki/Format-Security-FAQ

Many distros enable this Werror (ex. Arch, NixOS, Fedora)

Encountered here https://github.com/nix-community/nixpkgs-wayland/actions/runs/5447027039/jobs/9908550198#step:5:674