### PR TITLE
Do not abort when interfaces are older than expected

### DIFF
--- a/src/types/registry.c
+++ b/src/types/registry.c
@@ -29,12 +29,14 @@
 
 #define BIND(interface_name, known_version) \
 if (strcmp(interface, #interface_name) == 0) { \
-    self->interface_name = wl_registry_bind( \
-        wl_registry, \
-        name, \
-        &interface_name ## _interface, \
-        known_version \
-    ); \
+    if (version >= known_version) { \
+        self->interface_name = wl_registry_bind( \
+            wl_registry, \
+            name, \
+            &interface_name ## _interface, \
+            known_version \
+        ); \
+    } \
 }
 
 static void wl_registry_global_handler(


### PR DESCRIPTION
Instead, print a warning and let consumers abort if the missing interface is a fatal problem.

This happens with phosh 0.30, for example, which exposes `gtk_shell1` version 3. As of this patch, wl-clipboard works again but now prints `warning: interface gtk_shell1 wanted version 4 but got version 3` to standard error in this situation.