### PR TITLE
 registry: Don't fail on older gtk_shell

### DIFF
--- a/src/types/registry.c
+++ b/src/types/registry.c
@@ -37,6 +37,16 @@ if (strcmp(interface, #interface_name) == 0) { \
     ); \
 }
 
+#define BIND_OPTIONAL(interface_name, min_version) \
+if (strcmp(interface, #interface_name) == 0 && version >= min_version) { \
+    self->interface_name = wl_registry_bind( \
+        wl_registry, \
+        name, \
+        &interface_name ## _interface, \
+        min_version \
+    ); \
+}
+
 static void wl_registry_global_handler(
     void *data,
     struct wl_registry *wl_registry,
@@ -62,7 +72,7 @@ static void wl_registry_global_handler(
 #endif
 
 #ifdef HAVE_GTK_SHELL
-    BIND(gtk_shell1, 3)
+    BIND_OPTIONAL(gtk_shell1, 4)
 #endif
 
     /* Device managers */

--- a/src/types/registry.c
+++ b/src/types/registry.c
@@ -62,7 +62,7 @@ static void wl_registry_global_handler(
 #endif
 
 #ifdef HAVE_GTK_SHELL
-    BIND(gtk_shell1, 4)
+    BIND(gtk_shell1, 3)
 #endif
 
     /* Device managers */


### PR DESCRIPTION
Avoid using gtk_shell1 if it's too old as wl-{copy,paste} instead of aborting.
    
    Without this on phoc (using gtk_shell1 v3) it fails like:
    
```
      $ wl-paste
      wl_registry@2: error 0: invalid version for global gtk_shell1 (20): have 3, wanted 4
      wl_display_dispatch: Protocol error
```   
 
 As gtk_shell1 is a non standard protocol it's useful to be more graceful here.
