### PR TITLE
Fix wrong flushing issue

### DIFF
--- a/src/util/files.c
+++ b/src/util/files.c
@@ -69,7 +69,7 @@ void complain_about_closed_stdio(struct wl_display *wl_display) {
     FILE *tty = fopen("/dev/tty", "w");
     if (tty != NULL) {
         fprintf(tty, "%s\n", message);
-        fflush(stderr);
+        fflush(tty);
         abort();
     }
 


### PR DESCRIPTION
## Description

Closes #208.

## Changes Made

- Replaced `fflush(stderr);` with `fflush(tty);`