### PR TITLE
wl-copy: ignore SIGINT when backgrounded

### DIFF
--- a/src/wl-copy.c
+++ b/src/wl-copy.c
@@ -78,6 +78,8 @@ static void did_set_selection_callback(struct copy_action *copy_action) {
             perror("chdir /");
         }
         signal(SIGHUP, SIG_IGN);
+        signal(SIGINT, SIG_IGN);
+        signal(SIGQUIT, SIG_IGN);
         pid_t pid = fork();
         if (pid < 0) {
             perror("fork");


### PR DESCRIPTION
Given a command like

    echo foo | wl-copy

Unlike bash, the fish shell puts wl-copy in the shell's process
group [1], which can be observed with "ps -o pid,pgid,comm,args".
On VSCode's integrated terminal, this causes the issue that Control+C
will kill wl-copy, clearing the clipboard. fish has worked around
this[2] but still we should fix the command described above.
I'll try to look into changing the fish behavior but chances are
it's complicated.

Let's block SIGINT and SIGQUIT in the background process.
This will make wl-copy behave as if launched as

    bash -c "wl-copy &"

because according to Bash documentation[3] that's how background
commands in noninteractive shells should behave:

> When job control is not in effect, asynchronous commands ignore
> SIGINT and SIGQUIT in addition to these inherited handlers.

fish implements this too, but the bug happens on interactive shells.

[1]: https://github.com/fish-shell/fish-shell/commit/f3736e8fdf77652231527383ebbd9d96e71cec4d
[2]: https://github.com/fish-shell/fish-shell/commit/b3444ea12847217344ee926d2a0dc754b9cbc515
[3]: https://www.gnu.org/software/bash/manual/html_node/Signals.html
