### PR TITLE
Add support for ext-data-control-v1

### DIFF
--- a/src/includes/selection-protocols.h
+++ b/src/includes/selection-protocols.h
@@ -35,4 +35,8 @@
 #    include "wlr-data-control.h"
 #endif
 
+#ifdef HAVE_EXT_DATA_CONTROL
+#    include "ext-data-control.h"
+#endif
+
 #endif /* INCLUDES_SELECTION_PROTOCOLS_H */

--- a/src/protocol/meson.build
+++ b/src/protocol/meson.build
@@ -14,6 +14,7 @@ if wayland_scanner.found()
     # these are bundled
     have_gtk_primary_selection = true
     have_wlr_data_control = true
+    have_ext_data_control = wayland_protocols.found() and wayland_protocols.version().version_compare('>= 1.39')
     have_gtk_shell = true
 
     if wayland.version().version_compare('>= 1.15')
@@ -27,6 +28,7 @@ else
     have_xdg_activation = false
     have_gtk_primary_selection = false
     have_wlr_data_control = false
+    have_ext_data_control = false
     have_gtk_shell = false
 endif
 
@@ -35,6 +37,7 @@ conf_data.set('HAVE_XDG_SHELL', have_xdg_shell)
 conf_data.set('HAVE_WP_PRIMARY_SELECTION', have_wp_primary_selection)
 conf_data.set('HAVE_GTK_PRIMARY_SELECTION', have_gtk_primary_selection)
 conf_data.set('HAVE_WLR_DATA_CONTROL', have_wlr_data_control)
+conf_data.set('HAVE_EXT_DATA_CONTROL', have_ext_data_control)
 conf_data.set('HAVE_XDG_ACTIVATION', have_xdg_activation)
 conf_data.set('HAVE_GTK_SHELL', have_gtk_shell)
 
@@ -70,6 +73,11 @@ endif
 if have_wlr_data_control
     wlr_data_control_xml = 'wlr-data-control-unstable-v1.xml'
     protocols += [['wlr-data-control', wlr_data_control_xml]]
+endif
+
+if have_ext_data_control
+    ext_data_control_xml = join_paths(protocols_path, 'staging', 'ext-data-control', 'ext-data-control-v1.xml')
+    protocols += [['ext-data-control', ext_data_control_xml]]
 endif
 
 if have_xdg_activation

--- a/src/types/device-manager.c
+++ b/src/types/device-manager.c
@@ -138,3 +138,23 @@ GET_DEVICE(
 INIT(zwlr_data_control_manager_v1)
 
 #endif /* HAVE_WLR_DATA_CONTROL */
+
+/* ext-data-control implementation */
+
+#ifdef HAVE_EXT_DATA_CONTROL
+
+CREATE_SOURCE(
+    ext_data_control_manager_v1,
+    ext_data_control_source_v1,
+    create_data_source
+)
+
+GET_DEVICE(
+    ext_data_control_manager_v1,
+    ext_data_control_device_v1,
+    get_data_device
+)
+
+INIT(ext_data_control_manager_v1)
+
+#endif /* HAVE_EXT_DATA_CONTROL */

--- a/src/types/device-manager.h
+++ b/src/types/device-manager.h
@@ -69,4 +69,10 @@ void device_manager_init_zwlr_data_control_manager_v1(
 );
 #endif
 
+#ifdef HAVE_EXT_DATA_CONTROL
+void device_manager_init_ext_data_control_manager_v1(
+    struct device_manager *self
+);
+#endif
+
 #endif /* TYPES_DEVICE_MANAGER_H */

--- a/src/types/device.h
+++ b/src/types/device.h
@@ -71,4 +71,8 @@ void device_init_zwp_primary_selection_device_v1(struct device *self);
 void device_init_zwlr_data_control_device_v1(struct device *self);
 #endif
 
+#ifdef HAVE_EXT_DATA_CONTROL
+void device_init_ext_data_control_device_v1(struct device *self);
+#endif
+
 #endif /* TYPES_DEVICE_H */

--- a/src/types/offer.c
+++ b/src/types/offer.c
@@ -105,3 +105,13 @@ INIT(zwlr_data_control_offer_v1)
 
 #endif /* HAVE_WLR_DATA_CONTROL */
 
+
+/* ext-data-control implementation */
+
+#ifdef HAVE_EXT_DATA_CONTROL
+
+OFFER_HANDLER(ext_data_control_offer_v1)
+LISTENER(ext_data_control_offer_v1)
+INIT(ext_data_control_offer_v1)
+
+#endif /* HAVE_EXT_DATA_CONTROL */

--- a/src/types/offer.h
+++ b/src/types/offer.h
@@ -61,4 +61,8 @@ void offer_init_zwp_primary_selection_offer_v1(struct offer *self);
 void offer_init_zwlr_data_control_offer_v1(struct offer *self);
 #endif
 
+#ifdef HAVE_EXT_DATA_CONTROL
+void offer_init_ext_data_control_offer_v1(struct offer *self);
+#endif
+
 #endif /* TYPES_OFFER_H */

--- a/src/types/registry.h
+++ b/src/types/registry.h
@@ -69,6 +69,10 @@ struct registry {
     struct zwlr_data_control_manager_v1
         *zwlr_data_control_manager_v1;
 #endif
+#ifdef HAVE_EXT_DATA_CONTROL
+    struct ext_data_control_manager_v1
+        *ext_data_control_manager_v1;
+#endif
 };
 
 void registry_init(struct registry *self);

--- a/src/types/source.c
+++ b/src/types/source.c
@@ -127,3 +127,14 @@ INIT(zwlr_data_control_source_v1)
 
 #endif /* HAVE_WLR_DATA_CONTROL */
 
+
+/* ext-data-control implementation */
+
+#ifdef HAVE_EXT_DATA_CONTROL
+
+SEND_HANDLER(ext_data_control_source_v1)
+CANCELLED_HANDLER(ext_data_control_source_v1)
+LISTENER(ext_data_control_source_v1)
+INIT(ext_data_control_source_v1)
+
+#endif /* HAVE_EXT_DATA_CONTROL */

--- a/src/types/source.h
+++ b/src/types/source.h
@@ -52,4 +52,8 @@ void source_init_zwp_primary_selection_source_v1(struct source *self);
 void source_init_zwlr_data_control_source_v1(struct source *self);
 #endif
 
+#ifdef HAVE_EXT_DATA_CONTROL
+void source_init_ext_data_control_source_v1(struct source *self);
+#endif
+
 #endif /* TYPES_SOURCE_H */

--- a/src/util/misc.c
+++ b/src/util/misc.c
@@ -49,15 +49,15 @@ void complain_about_selection_support(int primary) {
 }
 
 void complain_about_watch_mode_support() {
-#ifdef HAVE_WLR_DATA_CONTROL
+#if defined(HAVE_WLR_DATA_CONTROL) || defined(HAVE_EXT_DATA_CONTROL)
     bail(
         "Watch mode requires a compositor that supports"
-        " the wlroots data-control protocol"
+        " the data-control protocol"
     );
 #else
     bail(
         "wl-clipboard was built without support for"
-        " the wlroots data-control protocol"
+        " the data-control protocol"
     );
 #endif
 }


### PR DESCRIPTION
The ext-data-control protocol is identical to the wlr-data-control protocol, except that it is governed by the wayland-protocols now. This change was tested in Plasma Wayland with and without the ext_data_control_manager_v1 global.

Closes #242