### PR TITLE
fix: correct spelling issues across docs and helpers

### DIFF
--- a/completions/fish/wl-paste.fish
+++ b/completions/fish/wl-paste.fish
@@ -22,7 +22,7 @@ function __wl_paste_types --description 'Print types with context'
 
     # Note fish does not handle passing unset variables
     # to commands well, thus setting clip to "--primary" and passing
-    # that to wl-paste wont work, so if statements are used instead
+    # that to wl-paste won't work, so if statements are used instead
     if test -n "$seat"; and test -n "$clip"
         wl-paste 2>/dev/null --seat "$seat" -p -l
     else if test -n "$seat"

--- a/completions/zsh/_wl-copy
+++ b/completions/zsh/_wl-copy
@@ -22,7 +22,7 @@ __all_seats() {
 	fi
 
 	if [[ -z $seats ]]; then
-		# seat0 is always a vaild seat and covers most cases, so its a good fallback.
+		# seat0 is always a valid seat and covers most cases, so it's a good fallback.
 		compadd "$@" - seat0
 	else
 		compadd "$@" -a seats

--- a/data/wl-clipboard.1
+++ b/data/wl-clipboard.1
@@ -157,7 +157,7 @@ future extensions). However, the currently existing Wayland clipboard protocols
 don't let wl-clipboard identify the cases where \fBclear\fR and \fBsensitive\fR
 values should be set. For this reason, currently, wl-clipboard never actually
 sets \fBCLIPBOARD_STATE\fR to \fBclear\fR, and only sets it to \fBsensitive\fR
-when it enounters \fBx-kde-passwordManagerHint\fR among the MIME types.
+when it encounters \fBx-kde-passwordManagerHint\fR among the MIME types.
 .IP
 The \fBCLIPBOARD_STATE\fR protocol was intentionally designed to not be specific
 to either wl-clipboard or Wayland; in fact, other clipboard tools are encouraged

--- a/src/types/popup-surface.c
+++ b/src/types/popup-surface.c
@@ -84,7 +84,7 @@ void popup_surface_init(struct popup_surface *self) {
 
     if (self->wl_surface == NULL) {
         /* It's possible that we were given focus
-         * (without ever commiting a buffer) during
+         * (without ever committing a buffer) during
          * the above roundtrip, in which case we have
          * already fired the callback and have likely
          * already destroyed the surface. No need to

--- a/src/util/files.c
+++ b/src/util/files.c
@@ -296,7 +296,7 @@ char *infer_mime_type_from_name(const char *file_path) {
 char *dump_stdin_into_a_temp_file() {
     /* Pick a name for the file we'll be
      * creating inside that directory. We
-     * try to preserve the origial name for
+     * try to preserve the original name for
      * the mime type inference to work.
      */
     char *original_path = path_for_fd(STDIN_FILENO);


### PR DESCRIPTION
- fix typos in CLIPBOARD_STATE man page entry (@data/wl-clipboard.1#152-160)
- clean up wording in fish and zsh completions (@completions/fish/wl-paste.fish#23-33, @completions/zsh/_wl-copy#16-29)
- correct comments in popup surface and file helpers (@src/types/popup-surface.c#81-95, @src/util/files.c#247-256)

Author: rezky_nightky <with.rezky@gmail.com>
Timestamp: 2025-12-01T18:50:09Z
Repository: wl-clipboard
Branch: master
Signing: GPG (989AF9F0)
Performance: 5 files, +5/-5 lines