### PR TITLE
use file(1) over xdg-mime

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -2,6 +2,7 @@ wayland = dependency(
     'wayland-client',
     default_options: ['tests=false', 'documentation=false', 'dtd_validation=false']
 )
+magic = dependency('libmagic')
 
 cc = meson.get_compiler('c')
 have_memfd = cc.has_header_symbol('sys/syscall.h', 'SYS_memfd_create')
@@ -52,7 +53,7 @@ lib = static_library(
     'types/registry.c',
     'types/copy-action.h',
     'types/copy-action.c',
-    dependencies: wayland,
+    dependencies: [wayland, magic],
     link_with: protocol_deps
 )
 
@@ -60,7 +61,7 @@ executable(
     'wl-copy',
     'wl-copy.c',
     protocol_headers,
-    dependencies: wayland,
+    dependencies: [wayland, magic],
     link_with: lib,
     install: true
 )
@@ -68,7 +69,7 @@ executable(
     'wl-paste',
     'wl-paste.c',
     protocol_headers,
-    dependencies: wayland,
+    dependencies: [wayland, magic],
     link_with: lib,
     install: true
 )

--- a/src/meson.build
+++ b/src/meson.build
@@ -2,7 +2,6 @@ wayland = dependency(
     'wayland-client',
     default_options: ['tests=false', 'documentation=false', 'dtd_validation=false']
 )
-magic = dependency('libmagic')
 
 cc = meson.get_compiler('c')
 have_memfd = cc.has_header_symbol('sys/syscall.h', 'SYS_memfd_create')
@@ -53,7 +52,7 @@ lib = static_library(
     'types/registry.c',
     'types/copy-action.h',
     'types/copy-action.c',
-    dependencies: [wayland, magic],
+    dependencies: wayland,
     link_with: protocol_deps
 )
 
@@ -61,7 +60,7 @@ executable(
     'wl-copy',
     'wl-copy.c',
     protocol_headers,
-    dependencies: [wayland, magic],
+    dependencies: wayland,
     link_with: lib,
     install: true
 )
@@ -69,7 +68,7 @@ executable(
     'wl-paste',
     'wl-paste.c',
     protocol_headers,
-    dependencies: [wayland, magic],
+    dependencies: wayland,
     link_with: lib,
     install: true
 )

--- a/src/types/copy-action.c
+++ b/src/types/copy-action.c
@@ -94,13 +94,15 @@ static void do_send(struct source *source, const char *mime_type, int fd) {
 
     /* Copy the file to the given file descriptor */
     if (lseek(self->fd_to_copy_from, 0, SEEK_SET) != 0) {
+        perror("Could not seek anonymous file");
         close(fd);
-        bail("Could not seek anonymous file");
+        return;
     }
 
     if (copy_fd(self->fd_to_copy_from, fd) != 0) {
+        perror("Could not paste");
         close(fd);
-        bail("Could not paste");
+        return;
     }
 
     close(fd);

--- a/src/types/copy-action.c
+++ b/src/types/copy-action.c
@@ -21,6 +21,7 @@
 #include "types/source.h"
 #include "types/popup-surface.h"
 
+#include "util/files.h"
 #include "util/misc.h"
 
 #include <stdint.h>
@@ -86,72 +87,23 @@ static void do_send(struct source *source, const char *mime_type, int fd) {
         return;
     }
 
-    if (self->fd_to_copy_from != -1) {
-        /* Copy the file to the given file descriptor
-         * by spawning an appropriate cat process.
-         */
-        pid_t pid = fork();
-        if (pid < 0) {
-            perror("fork");
-            close(fd);
-            return;
-        }
-        if (pid == 0) {
-            dup2(self->fd_to_copy_from, STDIN_FILENO);
-            close(self->fd_to_copy_from);
-            dup2(fd, STDOUT_FILENO);
-            close(fd);
-            signal(SIGHUP, SIG_DFL);
-            signal(SIGPIPE, SIG_DFL);
-            execlp("cat", "cat", NULL);
-            perror("exec cat");
-            exit(1);
-        }
+    if (self->fd_to_copy_from == -1) {
         close(fd);
-        /* Wait for the cat process to exit. This effectively
-         * means waiting for the other side to read the whole
-         * file. In theory, a malicious client could perform a
-         * denial-of-serivice attack against us. Perhaps we
-         * should switch to an asynchronous child waiting scheme
-         * instead.
-         */
-        waitpid(pid, NULL, 0);
-        /* Seek back to the beginning of the file */
-        off_t rc = lseek(self->fd_to_copy_from, 0, SEEK_SET);
-        if (rc < 0) {
-            perror("lseek");
-        }
-    } else {
-        /* We'll perform the copy ourselves */
-        FILE *f = fdopen(fd, "w");
-        if (f == NULL) {
-            perror("fdopen");
-            close(fd);
-            return;
-        }
-
-        if (self->data_to_copy.ptr != NULL) {
-            /* Just copy the given chunk of data */
-            fwrite(self->data_to_copy.ptr, 1, self->data_to_copy.len, f);
-        } else if (self->argv_to_copy != NULL) {
-            /* Copy an argv-style string array,
-             * inserting spaces between items.
-             */
-            int is_first = 1;
-            for (argv_t word = self->argv_to_copy; *word != NULL; word++) {
-                if (!is_first) {
-                    fwrite(" ", 1, 1, f);
-                }
-                is_first = 0;
-                fwrite(*word, 1, strlen(*word), f);
-            }
-        } else {
-            bail("Unreachable: nothing to copy");
-        }
-
-        fclose(f);
+        bail("Unreachable: nothing to copy");
     }
 
+    /* Copy the file to the given file descriptor */
+    if (lseek(self->fd_to_copy_from, 0, SEEK_SET) != 0) {
+        close(fd);
+        bail("Could not seek anonymous file");
+    }
+
+    if (copy_fd(self->fd_to_copy_from, fd) != 0) {
+        close(fd);
+        bail("Could not paste");
+    }
+
+    close(fd);
 
     if (self->pasted_callback != NULL) {
         self->pasted_callback(self);

--- a/src/types/copy-action.h
+++ b/src/types/copy-action.h
@@ -39,16 +39,8 @@ struct copy_action {
     void (*pasted_callback)(struct copy_action *self);
     void (*cancelled_callback)(struct copy_action *self);
 
-    /* Exactly one of these fields must be non-null if the source
-     * is non-null, otherwise all these fields must be null.
-     * The null value for fd_to_copy_from is -1.
-     */
+    /* May be -1 if clipboard is empty */
     int fd_to_copy_from;
-    argv_t argv_to_copy;
-    struct {
-        const char *ptr;
-        size_t len;
-    } data_to_copy;
 };
 
 void copy_action_init(struct copy_action *self);

--- a/src/util/files.c
+++ b/src/util/files.c
@@ -36,6 +36,7 @@
 #include <sys/wait.h>
 #include <signal.h>
 #include <syslog.h>
+#include <magic.h>
 
 #ifdef HAVE_MEMFD
 #    include <sys/syscall.h> // syscall, SYS_memfd_create
@@ -142,67 +143,33 @@ char *path_for_fd(int fd) {
 }
 
 char *infer_mime_type_from_contents(const char *file_path) {
-    /* Spawn xdg-mime query filetype */
-    int pipefd[2];
-    int rc = pipe(pipefd);
-    if (rc < 0) {
-        perror("pipe");
+    /* use libmagic to check filetype */
+    magic_t cookie;
+    const char *res;
+    char *mutable;
+
+    if ((cookie = magic_open(MAGIC_MIME_TYPE)) == NULL) {
         return NULL;
     }
 
-    pid_t pid = fork();
-    if (pid < 0) {
-        perror("fork");
-        close(pipefd[0]);
-        close(pipefd[1]);
-        return NULL;
-    }
-    if (pid == 0) {
-        dup2(pipefd[1], STDOUT_FILENO);
-        close(pipefd[0]);
-        close(pipefd[1]);
-        int devnull = open("/dev/null", O_RDONLY);
-        if (devnull >= 0) {
-            dup2(devnull, STDIN_FILENO);
-            close(devnull);
-        } else {
-            /* If we cannot open /dev/null, just close stdin */
-            close(STDIN_FILENO);
-        }
-        signal(SIGHUP, SIG_DFL);
-        signal(SIGPIPE, SIG_DFL);
-        execlp("xdg-mime", "xdg-mime", "query", "filetype", file_path, NULL);
-        exit(1);
-    }
-
-    close(pipefd[1]);
-    int wstatus;
-    waitpid(pid, &wstatus, 0);
-
-    /* See if that worked */
-    if (!WIFEXITED(wstatus) || WEXITSTATUS(wstatus) != 0) {
-        close(pipefd[0]);
+    if (magic_load(cookie, NULL)) {
+        magic_close(cookie);
         return NULL;
     }
 
-    /* Read the result */
-    char *res = malloc(256);
-    ssize_t len = read(pipefd[0], res, 256);
-    close(pipefd[0]);
-    if (len <= 0) {
-        free(res);
+    if ((res = magic_file(cookie, file_path)) == NULL) {
+        magic_close(cookie);
         return NULL;
     }
-    /* Trim the newline */
-    len--;
-    res[len] = 0;
 
     if (str_has_prefix(res, "inode/")) {
-        free(res);
+        magic_close(cookie);
         return NULL;
     }
 
-    return res;
+    mutable = strdup(res);
+    magic_close(cookie);
+    return mutable;
 }
 
 static char *search_mime_dot_types_for_ext(const char *ext) {

--- a/src/util/files.c
+++ b/src/util/files.c
@@ -36,7 +36,6 @@
 #include <sys/wait.h>
 #include <signal.h>
 #include <syslog.h>
-#include <magic.h>
 
 #ifdef HAVE_MEMFD
 #    include <sys/syscall.h> // syscall, SYS_memfd_create
@@ -100,20 +99,33 @@ int create_anonymous_file() {
     return fileno(tmpfile());
 }
 
-void trim_trailing_newline(const char *file_path) {
-    int fd = open(file_path, O_RDWR);
-    if (fd < 0) {
-        perror("open file for trimming");
-        return;
-    }
+int copy_fd(int src, int dest) {
+    /* Copy data between two file descriptors */
 
+    char *buf[256]; /* Arbitrary buffer size, can be made a macro */
+    ssize_t rlen, wlen, written;
+
+    while ((rlen = read(src, buf, 256)) > 0) {
+        for (written = 0; written < rlen; written += wlen) {
+            if ((wlen = write(dest, buf + written, rlen - written)) < 0) {
+                return 1;
+            }
+        }
+    }
+    if (rlen < 0) {
+        return 1;
+    }
+    return 0;
+}
+
+void trim_trailing_newline(int fd) {
     int seek_res = lseek(fd, -1, SEEK_END);
     if (seek_res < 0 && errno == EINVAL) {
         /* It was an empty file */
-        goto out;
+        return;
     } else if (seek_res < 0) {
         perror("lseek");
-        goto out;
+        return;
     }
     /* If the seek was successful, seek_res is the
      * new file size after trimming the newline.
@@ -122,18 +134,16 @@ void trim_trailing_newline(const char *file_path) {
     int read_res = read(fd, &last_char, 1);
     if (read_res != 1) {
         perror("read");
-        goto out;
+        return;
     }
     if (last_char != '\n') {
-        goto out;
+        return;
     }
 
     int rc = ftruncate(fd, seek_res);
     if (rc < 0) {
         perror("ftruncate");
     }
-out:
-    close(fd);
 }
 
 char *path_for_fd(int fd) {
@@ -142,34 +152,67 @@ char *path_for_fd(int fd) {
     return realpath(fdpath, NULL);
 }
 
-char *infer_mime_type_from_contents(const char *file_path) {
-    /* use libmagic to check filetype */
-    magic_t cookie;
-    const char *res;
-    char *mutable;
-
-    if ((cookie = magic_open(MAGIC_MIME_TYPE)) == NULL) {
+char *infer_mime_type_from_contents(int fd) {
+    /* Spawn file(1) to check filetype */
+    if (lseek(fd, 0, SEEK_SET) != 0) {
+        perror("lseek");
         return NULL;
     }
 
-    if (magic_load(cookie, NULL)) {
-        magic_close(cookie);
+    int pipefd[2];
+    int rc = pipe(pipefd);
+    if (rc < 0) {
+        perror("pipe");
         return NULL;
     }
 
-    if ((res = magic_file(cookie, file_path)) == NULL) {
-        magic_close(cookie);
+    pid_t pid = fork();
+    if (pid < 0) {
+        perror("fork");
+        close(pipefd[0]);
+        close(pipefd[1]);
         return NULL;
     }
+    if (pid == 0) {
+        dup2(fd, STDIN_FILENO);
+        close(fd);
+        dup2(pipefd[1], STDOUT_FILENO);
+        close(pipefd[0]);
+        close(pipefd[1]);
+        signal(SIGHUP, SIG_DFL);
+        signal(SIGPIPE, SIG_DFL);
+        execlp("file", "file", "--brief", "--mime-type", "-", (char *) NULL);
+        exit(1);
+    }
+
+    close(pipefd[1]);
+    int wstatus;
+    waitpid(pid, &wstatus, 0);
+
+    /* See if that worked */
+    if (!WIFEXITED(wstatus) || WEXITSTATUS(wstatus) != 0) {
+        close(pipefd[0]);
+        return NULL;
+    }
+
+    /* Read the result */
+    char *res = malloc(256);
+    ssize_t len = read(pipefd[0], res, 256);
+    close(pipefd[0]);
+    if (len <= 0) {
+        free(res);
+        return NULL;
+    }
+    /* Trim the newline */
+    len--;
+    res[len] = 0;
 
     if (str_has_prefix(res, "inode/")) {
-        magic_close(cookie);
+        free(res);
         return NULL;
     }
 
-    mutable = strdup(res);
-    magic_close(cookie);
-    return mutable;
+    return res;
 }
 
 static char *search_mime_dot_types_for_ext(const char *ext) {
@@ -257,68 +300,4 @@ char *infer_mime_type_from_name(const char *file_path) {
     }
     free(file_path_dup);
     return mime_type;
-}
-
-/* Returns the name of a new file */
-char *dump_stdin_into_a_temp_file() {
-    /* Pick a name for the file we'll be
-     * creating inside that directory. We
-     * try to preserve the original name for
-     * the mime type inference to work.
-     */
-    char *original_path = path_for_fd(STDIN_FILENO);
-    char *name = original_path != NULL ? basename(original_path) : "stdin";
-
-    /* Create a temp directory to host out file */
-    const char *tmpdir = getenv("TMPDIR");
-    if (tmpdir == NULL) {
-        tmpdir = "/tmp";
-    }
-    size_t tmpdir_len = strlen(tmpdir);
-    static const char dir_template[] = "wl-copy-buffer-XXXXXX";
-    char *path = malloc(
-        tmpdir_len + 1 + strlen(dir_template) + 1 + strlen(name) + 1
-    );
-    memcpy(path, tmpdir, tmpdir_len);
-    path[tmpdir_len] = '/';
-    memcpy(path + tmpdir_len + 1, dir_template, strlen(dir_template));
-    size_t prefix_len = tmpdir_len + 1 + strlen(dir_template);
-    path[prefix_len] = 0;
-
-    if (mkdtemp(path) != path) {
-        perror("mkdtemp");
-        exit(1);
-    }
-
-    path[prefix_len] = '/';
-    strcpy(path + prefix_len + 1, name);
-
-    /* Spawn cat to perform the copy */
-    pid_t pid = fork();
-    if (pid < 0) {
-        perror("fork");
-        exit(1);
-    }
-    if (pid == 0) {
-        int fd = creat(path, S_IRUSR | S_IWUSR);
-        if (fd < 0) {
-            perror("creat");
-            exit(1);
-        }
-        dup2(fd, STDOUT_FILENO);
-        close(fd);
-        signal(SIGHUP, SIG_DFL);
-        signal(SIGPIPE, SIG_DFL);
-        execlp("cat", "cat", NULL);
-        perror("exec cat");
-        exit(1);
-    }
-
-    int wstatus;
-    waitpid(pid, &wstatus, 0);
-    free(original_path);
-    if (!WIFEXITED(wstatus) || WEXITSTATUS(wstatus) != 0) {
-        bail("Failed to copy the file");
-    }
-    return path;
 }

--- a/src/util/files.h
+++ b/src/util/files.h
@@ -24,17 +24,13 @@ void complain_about_closed_stdio(struct wl_display *wl_display);
 
 int create_anonymous_file(void);
 
-void trim_trailing_newline(const char *file_path);
+int copy_fd(int src, int dest);
 
-/* These functions return owned strings, so make sure
- * to free() their return values when done with them.
- */
+void trim_trailing_newline(int fd);
 
+/* These functions return malloc'd strings */
 char *path_for_fd(int fd);
-char *infer_mime_type_from_contents(const char *file_path);
+char *infer_mime_type_from_contents(int fd);
 char *infer_mime_type_from_name(const char *file_path);
-
-/* Returns the name of a new file */
-char *dump_stdin_into_a_temp_file(void);
 
 #endif /* UTIL_FILES_H */

--- a/src/wl-copy.c
+++ b/src/wl-copy.c
@@ -255,46 +255,41 @@ int main(int argc, argv_t argv) {
     copy_action->sensitive = options.sensitive;
 
     if (!options.clear) {
+        copy_action->fd_to_copy_from = create_anonymous_file();
+        if (copy_action->fd_to_copy_from < 0) {
+            perror("Failed to open anonymous file");
+            return 1;
+        }
+
         if (optind < argc) {
-            /* Copy our command-line arguments */
-            copy_action->argv_to_copy = &argv[optind];
+            /* Write command line arguments to our anonymous file */
+            ssize_t wlen, written;
+            int is_first = 1;
+
+            for (argv_t word = argv + optind; *word != NULL; word++) {
+                if (!is_first) {
+                    write(copy_action->fd_to_copy_from, " ", 1);
+                }
+                is_first = 0;
+                for (written = 0; written < strlen(*word); written += wlen) {
+                    if ((wlen = write(copy_action->fd_to_copy_from, *word + written, strlen(*word) - written)) < 0) {
+                        perror("Could not write to anonymous file");
+                        return 1;
+                    }
+                }
+            }
         } else {
-            /* Copy data from our stdin.
-             * It's important that we only do this
-             * after going through the initial stages
-             * that are likely to result in errors,
-             * so that we don't forget to clean up
-             * the temp file.
-             */
-            char *temp_file = dump_stdin_into_a_temp_file();
-            if (options.trim_newline) {
-                trim_trailing_newline(temp_file);
-            }
-            if (options.mime_type == NULL) {
-                options.mime_type = infer_mime_type_from_contents(temp_file);
-            }
-            copy_action->fd_to_copy_from = open(
-                temp_file,
-                O_RDONLY | O_CLOEXEC
-            );
-            if (copy_action->fd_to_copy_from < 0) {
-                perror("Failed to open temp file");
+            /* Write stdin into our anonymous file. */
+            if (copy_fd(STDIN_FILENO, copy_action->fd_to_copy_from) != 0) {
+                perror("Could not write to anonymous file");
                 return 1;
             }
-            /* Now, remove the temp file and its
-             * containing directory. We still keep
-             * access to the file through our open
-             * file descriptor.
-             */
-            int rc = unlink(temp_file);
-            if (rc < 0) {
-                perror("Failed to unlink temp file");
-            }
-            rc = rmdir(dirname(temp_file));
-            if (rc < 0) {
-                perror("Failed to remove temp file directory");
-            }
-            free(temp_file);
+        }
+        if (options.trim_newline) {
+            trim_trailing_newline(copy_action->fd_to_copy_from);
+        }
+        if (options.mime_type == NULL) {
+            options.mime_type = infer_mime_type_from_contents(copy_action->fd_to_copy_from);
         }
 
         /* Create the source */


### PR DESCRIPTION
Hello, I recently started using this tool, and ran into a problem with xdg-mime. Taking a look at the open issues, I found this post:

> this could probably be resolved by using a library like libmagic for sniffing content type instead of spawning an xdg-mime child process 

 _Originally posted by @r0chd in [#258](https://github.com/bugaevc/wl-clipboard/issues/258#issuecomment-3621107333)_

This is about as simple an implementation as it gets, so let me know if there is anything I missed.